### PR TITLE
17

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,4 +759,10 @@ When validating a value matches an interface it may be desirable to instead use 
 - Add: `asInstance` and `asOptInstance` to allow casting a value to an instance of a given class.
 - Breaking Change: `asRecord`, `asOptRecord`, `asRecordRecursive` and `asOptRecordRecursive` have been renamed to `asDictionary`, `asOptDictionary`, `asDictionaryOf` and `asOptDictionaryOf` respectively.
 - Breaking Change: `asArrayRecursive` and `asOptArrayRecursive` have been renamed to `asArrayOf` and `asOptArrayOf` respectively.
-- Breaking Change: rename `TypeAssert` to `TypeCheck`
+- Breaking Change: rename `TypeAssert` to `TypeCheck`.
+
+### 2.1.0
+
+- Add: `makeStrictPartial` for converting `Partial<T>` to `StrictPartial`.
+- Add: types `StrictPartial` and `FuzzyPartial`, variants of the inbuilt `Partial` type.
+- Add: type `StrictRequired`, variant of `Required`.

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ When validating a value matches an interface it may be desirable to instead use 
 
 - ### FuzzyPartial
 
-  A variant of the `Partial<T>` inbuilt, and closely related to `StrictPartial`. `Partial` makes no guarantees about the members of the type `T`, as such they can be unions of `null`. This can introduce inconsistency for users of the type; expecting that members can be specified using either `null` or `undefined`, where only some can also use `null`. `FuzzyPartial` resolves this by specifying that all members of the type `T` can also be `null`, ensuring a consistent interface.
+  A variant of the `Partial<T>` inbuilt, and closely related to `StrictPartial`. `Partial` makes no guarantees about the members of the type `T`, as such they can be unions of `null`. This can introduce inconsistency for users of the type; expecting that members can be specified using either `null` or `undefined`, where only some can also use `null`. `FuzzyPartial` resolves this by specifying that all members of the type `T` can *ALSO* be `null`, ensuring a consistent interface.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ts-runtime-typecheck
 
 ![100% coverage](https://img.shields.io/badge/coverage-100%25-success)
-![100% coverage](https://img.shields.io/badge/dependencies-0-success)
+![0 dependencies](https://img.shields.io/badge/dependencies-0-success)
 ![npm](https://img.shields.io/npm/dm/ts-runtime-typecheck)
 
 Simple functions for validating complex data.
@@ -44,6 +44,7 @@ npm install ts-runtime-typecheck
   - [v1.1.1](#v111)
   - [v1.2.0](#v120)
   - [v2.0.0](#v200)
+  - [v2.1.0](#v210)
 
 ## Type Casts
 
@@ -650,6 +651,10 @@ When validating a value matches an interface it may be desirable to instead use 
 
   Takes an `unknown` value and converts it to it's *boolean* representation. A value that cannot be cleanly converted will trigger an error.
 
+- ### makeStrictPartial
+
+  Takes a value of the generic type `T` and returns a copy of the object excluding any members that were `Nullish`. The returned object meets the type `StrictPartial<T>`.
+
 ### Reference: Types
 
 - ### JSONValue
@@ -699,6 +704,18 @@ When validating a value matches an interface it may be desirable to instead use 
 - ### InterfacePattern
 
   An alias for a [`Dictionary`](#dictionary) of [`TypeAssert`](#typeassert) functions. When used in conjunction with [`isStruct`](#isstruct) or [`asStruct`](#asstruct) they can  validate an `object` against the equivalent interface to the pattern.
+
+- ### StrictRequired
+
+  A variant of the inbuilt `Required<T>`, which is the opposite of `Optional<T>` in that it subtracts the type `undefined` from each member of the type `T`. StrictRequired varies in that it also subtracts the type `null` from each member. Ensuring that all members meet the constraint `NonNullable`.
+
+- ### StrictPartial
+
+  A variant of the `Partial<T>` inbuilt, and closely related to `FuzzyPartial`. `Partial` makes no guarantees about the members of the type `T`, as such they can be unions of `null`. This can introduce inconsistency for users of the type; expecting that members can be specified using either `null` or `undefined`, where only some can also use `null`. `StrictPartial` resolves this by specifying that no members of the type `T` can be `null`, ensuring a consistent interface.
+
+- ### FuzzyPartial
+
+  A variant of the `Partial<T>` inbuilt, and closely related to `StrictPartial`. `Partial` makes no guarantees about the members of the type `T`, as such they can be unions of `null`. This can introduce inconsistency for users of the type; expecting that members can be specified using either `null` or `undefined`, where only some can also use `null`. `FuzzyPartial` resolves this by specifying that all members of the type `T` can also be `null`, ensuring a consistent interface.
 
 ## Changelog
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-runtime-typecheck",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A collection of common types for TypeScript along with dynamic type cast methods.",
   "main": "cjs/index.js",
   "module": "mjs/index.mjs",

--- a/src/FuzzyPartial.type.ts
+++ b/src/FuzzyPartial.type.ts
@@ -1,0 +1,3 @@
+export type FuzzyPartial<T> = {
+  [P in keyof T]?: T | null; 
+};

--- a/src/StrictPartial.type.ts
+++ b/src/StrictPartial.type.ts
@@ -1,0 +1,3 @@
+export type StrictPartial<T> = {
+  [P in keyof T]?: NonNullable<T[P]>;
+}

--- a/src/StrictRequired.type.ts
+++ b/src/StrictRequired.type.ts
@@ -1,0 +1,3 @@
+export type StrictRequired<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './type-check/is-union';
 export * from './type-check/is-recursive';
 
 export * from './type-coerce/make-primative';
+export * from './type-coerce/make-strict-partial';
 
 export { Index, Indexable } from './Index.type';
 export { JSONValue, JSONArray, JSONObject } from './JSONValue.type';
@@ -20,3 +21,6 @@ export { Nullish } from './Nullish.type';
 export { UnknownFunction, UnknownAsyncFunction } from './UnknownFunction.type';
 export { InterfacePattern } from './InterfacePattern.type';
 export { TypeCheck } from './TypeCheck.type';
+export { StrictPartial } from './StrictPartial.type';
+export { StrictRequired } from './StrictRequired.type';
+export { FuzzyPartial } from './FuzzyPartial.type';

--- a/src/type-check/is-primitive.test.ts
+++ b/src/type-check/is-primitive.test.ts
@@ -1,4 +1,4 @@
-import type { TypeCheck } from '../TypeAssert.type';
+import type { TypeCheck } from '../TypeCheck.type';
 import { isArray, isBoolean, isDefined, isDictionary, isFunction, isIndex, isIndexable, isNullish, isNumber, isOptArray, isOptBoolean, isOptDictionary, isOptFunction, isOptIndex, isOptIndexable, isOptNumber, isOptString, isString, isUndefined } from './is-primitive';
 
 describe('is primitive', () => {

--- a/src/type-check/is-struct.test.ts
+++ b/src/type-check/is-struct.test.ts
@@ -1,4 +1,4 @@
-import type { TypeAssert } from '../TypeAssert.type';
+import type { TypeCheck } from '../TypeCheck.type';
 
 import { isNumber, isString } from './is-primitive';
 import { isStruct, isOptStruct } from './is-struct';
@@ -81,7 +81,7 @@ describe('is struct', () => {
   });
 
   it('does not add a type to the label if the TypeAssert does not hold one', () => {
-    const test: TypeAssert<string> = (_obj: unknown): _obj is string => true;
+    const test: TypeCheck<string> = (_obj: unknown): _obj is string => true;
     const { TYPE_NAME } = isStruct({ a: test }); 
     expect(TYPE_NAME).toBe('{ a }');
   });
@@ -167,7 +167,7 @@ describe('is optional struct', () => {
   });
 
   it('does not add a type to the label if the TypeAssert does not hold one', () => {
-    const test: TypeAssert<string> = (_obj: unknown): _obj is string => true;
+    const test: TypeCheck<string> = (_obj: unknown): _obj is string => true;
     const { TYPE_NAME } = isOptStruct({ a: test }); 
     expect(TYPE_NAME).toBe('{ a }');
   });

--- a/src/type-coerce/make-strict-partial.test.ts
+++ b/src/type-coerce/make-strict-partial.test.ts
@@ -1,0 +1,14 @@
+import { makeStrictPartial } from './make-strict-partial';
+
+describe('make-strict-partial', () => {
+  it ('removes undefined keys from the object', () => {
+    const source = {
+      a: undefined,
+      b: undefined,
+      c: 12,
+    };
+    const result = makeStrictPartial(source);
+    expect(Object.keys(result)).toStrictEqual(['c']);
+    expect(result.c).toBe(12);
+  });
+});

--- a/src/type-coerce/make-strict-partial.ts
+++ b/src/type-coerce/make-strict-partial.ts
@@ -1,0 +1,15 @@
+import type { Dictionary } from '../Dictionary.type';
+import type { StrictPartial } from '../StrictPartial.type';
+import { isDefined } from '../type-check/is-primitive';
+
+export function makeStrictPartial<T extends Dictionary>(value: T): StrictPartial<T> {
+  const result: Dictionary<NonNullable<unknown>> = {};
+
+  for (const [key, prop] of Object.entries(value)) {
+    if (isDefined(prop)) {
+      result[key] = prop;
+    }
+  }
+
+  return result as StrictPartial<T>;
+}


### PR DESCRIPTION
closes #17 

Adds the function `makeStrictPartial` and related types for improving typing of `nullish` members in `Partial`. 